### PR TITLE
Percy reduction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,6 @@ script:
 - npm run dev &
 # suppresses Percy snapshots uploading unless Node.js is 12.x
 - if [[ $TRAVIS_NODE_VERSION != 12* ]]; then export PERCY_TOKEN=; fi
+# suppresses Percy snapshots uploading unless the branch is master
+- if [[ $TRAVIS_BRANCH != "master" ]]; then export PERCY_TOKEN=; fi
 - npx wait-on http-get://localhost:8080 && npm run cypress:run


### PR DESCRIPTION
- `PERCY_TOKEN` is reset unless the branch is master, to reduce Percy snapshots uploading.

close #30